### PR TITLE
Relax persistent-sqlite dependency bounds

### DIFF
--- a/yesod-auth-hashdb.cabal
+++ b/yesod-auth-hashdb.cabal
@@ -78,7 +78,7 @@ test-suite integration
                    , http-types
                    , monad-logger
                    , network-uri
-                   , persistent-sqlite  >= 2.1 && < 2.12
+                   , persistent-sqlite  >= 2.1 && < 2.14
                    , resourcet
                    , text
                    , unordered-containers


### PR DESCRIPTION
I tested this locally with the following `stack.yaml`:

```
resolver: lts-17.9
packages:
- .
extra-deps:
- persistent-2.13.0.1
- persistent-sqlite-2.13.0.0
- persistent-template-2.12.0.0
- lift-type-0.1.0.1
- yesod-persistent-1.6.0.7
```